### PR TITLE
Remove leading slash on reality path

### DIFF
--- a/pkg/reality/reality.go
+++ b/pkg/reality/reality.go
@@ -15,7 +15,7 @@ import (
 	"github.com/square/p2/pkg/util"
 )
 
-const REALITY_TREE string = "/reality"
+const REALITY_TREE string = "reality"
 
 type ConsulClient interface {
 	KV() *consulapi.KV


### PR DESCRIPTION
Because consul API is using concat instead of path.Join